### PR TITLE
issue-2245: Track vul status for nv images for 5.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	golang.org/x/sys v0.41.0
 	golang.org/x/time v0.14.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d
-	google.golang.org/grpc v1.79.1
+	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
 	gotest.tools/v3 v3.4.0
 	k8s.io/api v0.35.2


### PR DESCRIPTION
fix [#2245](https://github.com/neuvector/neuvector/issues/2245)